### PR TITLE
Add simple model selection demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ python app.py
 
 By default the server listens on port `5000`.
 
+You can also open a small web demo at [`/demo`](http://localhost:5000/demo) to
+select a model and enter feature values for a quick prediction.
+
 ## API
 
 ### `POST /predict`

--- a/app.py
+++ b/app.py
@@ -7,7 +7,7 @@ from functools import lru_cache
 
 import joblib
 import numpy as np
-from flask import Flask, jsonify, request
+from flask import Flask, jsonify, request, render_template
 
 
 app = Flask(__name__)
@@ -28,6 +28,22 @@ def load_model(name: str):
 @app.route("/")
 def hello_world():
     return "Hello, Flask!"
+
+
+@app.route("/models")
+def list_models():
+    """Return available model names."""
+    names = []
+    for filename in os.listdir(MODEL_DIR):
+        if filename.endswith("_50m_pipeline.pkl"):
+            names.append(filename.split("_", 1)[0])
+    return jsonify({"models": sorted(names)})
+
+
+@app.route("/demo")
+def demo_page():
+    """Serve the simple demo page."""
+    return render_template("demo.html")
 
 
 @app.route("/predict", methods=["POST"])

--- a/templates/demo.html
+++ b/templates/demo.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Wellbore Prediction Demo</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 2em; }
+        label { display: block; margin-top: 1em; }
+        input, select { padding: 0.5em; width: 300px; }
+        button { margin-top: 1em; padding: 0.5em 1em; }
+        #result { margin-top: 1em; font-weight: bold; }
+    </style>
+</head>
+<body>
+    <h1>Wellbore Prediction Demo</h1>
+    <label>
+        Model:
+        <select id="model-select"></select>
+    </label>
+    <label>
+        Features (comma separated):
+        <input id="features-input" type="text" placeholder="1.0, 2.0, 3.0">
+    </label>
+    <button id="predict-btn">Predict</button>
+    <div id="result"></div>
+
+<script>
+async function loadModels() {
+    const res = await fetch('/models');
+    if (!res.ok) return;
+    const data = await res.json();
+    const select = document.getElementById('model-select');
+    data.models.forEach(m => {
+        const opt = document.createElement('option');
+        opt.value = m;
+        opt.textContent = m;
+        select.appendChild(opt);
+    });
+}
+
+async function predict() {
+    const model = document.getElementById('model-select').value;
+    const featuresText = document.getElementById('features-input').value;
+    const features = featuresText.split(',').map(v => parseFloat(v.trim())).filter(v => !isNaN(v));
+    const res = await fetch('/predict', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ model: model, features: features })
+    });
+    const resultDiv = document.getElementById('result');
+    if (!res.ok) {
+        const data = await res.json();
+        resultDiv.textContent = 'Error: ' + (data.error || res.statusText);
+        return;
+    }
+    const data = await res.json();
+    resultDiv.textContent = 'Prediction: ' + data.prediction;
+}
+
+document.getElementById('predict-btn').addEventListener('click', predict);
+loadModels();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- serve a basic HTML page for interacting with the models
- expose `/models` endpoint for listing available models
- note the web demo in the README

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile app.py`
- `timeout 3 python app.py`

------
https://chatgpt.com/codex/tasks/task_e_686b49e68284832499181282db5988c2